### PR TITLE
chore: scope npm packages under @florinszilagyi org

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -53,11 +53,11 @@ jobs:
       - name: Install (workspace)
         run: pnpm install --frozen-lockfile
       - name: Build SDK
-        run: pnpm --filter anaf-ts-sdk run build
+        run: pnpm --filter @florinszilagyi/anaf-ts-sdk run build
       - name: Verify CLI
-        run: pnpm --filter anaf-cli run verify
+        run: pnpm --filter @florinszilagyi/anaf-cli run verify
       - name: Check COMMANDS.md is up to date
-        run: pnpm --filter anaf-cli run gen-docs:check
+        run: pnpm --filter @florinszilagyi/anaf-cli run gen-docs:check
       - name: Read CLI version
         id: read_version
         run: |
@@ -109,9 +109,9 @@ jobs:
       - name: Install (workspace)
         run: pnpm install --frozen-lockfile
       - name: Build SDK
-        run: pnpm --filter anaf-ts-sdk run build
+        run: pnpm --filter @florinszilagyi/anaf-ts-sdk run build
       - name: Build CLI bundle
-        run: pnpm --filter anaf-cli run build
+        run: pnpm --filter @florinszilagyi/anaf-cli run build
       - name: Build SEA binary
         run: |
           mkdir -p "cli/dist/sea/${TARGET}"
@@ -180,8 +180,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build CLI
         run: |
-          pnpm --filter anaf-ts-sdk run build
-          pnpm --filter anaf-cli run build
+          pnpm --filter @florinszilagyi/anaf-ts-sdk run build
+          pnpm --filter @florinszilagyi/anaf-cli run build
       - name: Publish to npm (dry-run default)
         run: |
           cd cli

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,12 +40,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build SDK
-        run: pnpm --filter anaf-ts-sdk run build
+        run: pnpm --filter @florinszilagyi/anaf-ts-sdk run build
 
       - name: Test SDK
-        run: pnpm --filter anaf-ts-sdk run validate
+        run: pnpm --filter @florinszilagyi/anaf-ts-sdk run validate
 
       - name: Publish SDK
-        run: pnpm --filter anaf-ts-sdk publish --access public --no-git-checks
+        run: pnpm --filter @florinszilagyi/anaf-ts-sdk publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ pnpm run verify                # full CI gate: build SDK → verify CLI (lint+bu
 pnpm run dev -- <args>         # run CLI in dev mode (tsx, no build needed for CLI changes)
 ```
 
-### SDK-specific (`pnpm --filter anaf-ts-sdk run <script>`)
+### SDK-specific (`pnpm --filter @florinszilagyi/anaf-ts-sdk run <script>`)
 
 ```bash
 build          # clean + CJS + ESM + types
@@ -37,7 +37,7 @@ test:ci        # unit tests with coverage
 lint:check     # eslint without fixing
 ```
 
-### CLI-specific (`pnpm --filter anaf-cli run <script>`)
+### CLI-specific (`pnpm --filter @florinszilagyi/anaf-cli run <script>`)
 
 ```bash
 build          # clean + tsc + esbuild bundle (dist/bin/anaf-cli.cjs)
@@ -52,9 +52,9 @@ verify         # lint + build + test (single CI gate)
 ### Running a single test
 
 ```bash
-pnpm --filter anaf-cli exec jest tests/services/lookupService.test.ts
-pnpm --filter anaf-cli exec jest tests/commands/groups/ctx.test.ts -t "ctxLs"
-pnpm --filter anaf-ts-sdk exec jest tests/ublBuilder.unit.test.ts
+pnpm --filter @florinszilagyi/anaf-cli exec jest tests/services/lookupService.test.ts
+pnpm --filter @florinszilagyi/anaf-cli exec jest tests/commands/groups/ctx.test.ts -t "ctxLs"
+pnpm --filter @florinszilagyi/anaf-ts-sdk exec jest tests/ublBuilder.unit.test.ts
 ```
 
 ## Architecture

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@florinszilagyi/anaf-cli",
-  "version": "0.1.0-preview.1",
+  "version": "1.0.0",
   "description": "CLI for the ANAF e-Factura SDK (anaf-ts-sdk)",
   "license": "MIT",
   "author": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "anaf-cli",
+  "name": "@florinszilagyi/anaf-cli",
   "version": "0.1.0-preview.1",
   "description": "CLI for the ANAF e-Factura SDK (anaf-ts-sdk)",
   "license": "MIT",
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/node": "^20.10.5",
-    "anaf-ts-sdk": "workspace:*",
+    "@florinszilagyi/anaf-ts-sdk": "workspace:*",
     "esbuild": "^0.21.5",
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",

--- a/cli/src/actions/overrideMerge.ts
+++ b/cli/src/actions/overrideMerge.ts
@@ -1,4 +1,4 @@
-import type { Party } from 'anaf-ts-sdk';
+import type { Party } from '@florinszilagyi/anaf-ts-sdk';
 import type { PartyOverride } from './types';
 
 export function mergePartyOverride(base: Party, override?: PartyOverride): Party {

--- a/cli/src/commands/groups/efactura.ts
+++ b/cli/src/commands/groups/efactura.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import type { Command } from 'commander';
-import type { MessageFilter } from 'anaf-ts-sdk';
+import type { MessageFilter } from '@florinszilagyi/anaf-ts-sdk';
 import type { CommandDeps } from '../buildProgram';
 import { CliError } from '../../output/errors';
 import { renderSuccess, writeBinary } from '../../output';

--- a/cli/src/services/authService.ts
+++ b/cli/src/services/authService.ts
@@ -1,4 +1,4 @@
-import { AnafAuthenticator } from 'anaf-ts-sdk';
+import { AnafAuthenticator } from '@florinszilagyi/anaf-ts-sdk';
 import { CliError } from '../output/errors';
 import type { Credential, CredentialService, CompanyService, ConfigStore, TokenRecord, TokenStore, Company, Environment } from '../state';
 

--- a/cli/src/services/efacturaService.ts
+++ b/cli/src/services/efacturaService.ts
@@ -10,7 +10,7 @@ import {
   type UploadOptions,
   type UploadResponse,
   type ValidationResult,
-} from 'anaf-ts-sdk';
+} from '@florinszilagyi/anaf-ts-sdk';
 import { CliError } from '../output/errors';
 import type { CompanyService, CredentialService, ConfigStore, TokenStore, Environment } from '../state';
 import type { LookupService } from './lookupService';

--- a/cli/src/services/lookupService.ts
+++ b/cli/src/services/lookupService.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { AnafDetailsClient, type AnafCompanyData, type AnafAsyncPollingConfig } from 'anaf-ts-sdk';
+import { AnafDetailsClient, type AnafCompanyData, type AnafAsyncPollingConfig } from '@florinszilagyi/anaf-ts-sdk';
 import { CliError } from '../output/errors';
 import { defaultXdgPaths, getXdgPaths, type XdgPaths } from '../state/paths';
 

--- a/cli/src/services/ublService.ts
+++ b/cli/src/services/ublService.ts
@@ -1,5 +1,5 @@
-import { UblBuilder } from 'anaf-ts-sdk';
-import type { AnafCompanyData, InvoiceInput, InvoiceLine, Party } from 'anaf-ts-sdk';
+import { UblBuilder } from '@florinszilagyi/anaf-ts-sdk';
+import type { AnafCompanyData, InvoiceInput, InvoiceLine, Party } from '@florinszilagyi/anaf-ts-sdk';
 import { CliError } from '../output/errors';
 import type { UblBuildAction, InvoiceLineAction, PartyOverride } from '../actions';
 import { mergePartyOverride } from '../actions/overrideMerge';

--- a/cli/tests/actions/overrideMerge.test.ts
+++ b/cli/tests/actions/overrideMerge.test.ts
@@ -1,5 +1,5 @@
 import { mergePartyOverride } from '../../src/actions/overrideMerge';
-import type { Party } from 'anaf-ts-sdk';
+import type { Party } from '@florinszilagyi/anaf-ts-sdk';
 
 const basePartyFn = (): Party => ({
   registrationName: 'Acme SRL',

--- a/cli/tests/commands/groups/lookup.test.ts
+++ b/cli/tests/commands/groups/lookup.test.ts
@@ -5,7 +5,7 @@ import { LookupService } from '../../../src/services';
 import { CliError } from '../../../src/output/errors';
 import { makeOutputContext } from '../../../src/output';
 import { lookupCompany, lookupCompanyAsync, lookupValidateCui } from '../../../src/commands/groups/lookup';
-import type { AnafCompanyData } from 'anaf-ts-sdk';
+import type { AnafCompanyData } from '@florinszilagyi/anaf-ts-sdk';
 
 describe('lookup group', () => {
   it('registers company, company-async, validate-cui', () => {

--- a/cli/tests/commands/jsonEnvelope.golden.test.ts
+++ b/cli/tests/commands/jsonEnvelope.golden.test.ts
@@ -7,7 +7,7 @@ import { CompanyService, CredentialService, ConfigStore, TokenStore } from '../.
 import { AuthService, LookupService, EfacturaService, UblService } from '../../src/services';
 import { getXdgPaths } from '../../src/state/paths';
 import { EXIT_CODES } from '../../src/output/exitCodes';
-import { AnafDetailsClient } from 'anaf-ts-sdk';
+import { AnafDetailsClient } from '@florinszilagyi/anaf-ts-sdk';
 
 class Cap extends Writable {
   buf = '';

--- a/cli/tests/services/authService.test.ts
+++ b/cli/tests/services/authService.test.ts
@@ -6,7 +6,7 @@ import { CompanyService, CredentialService, ConfigStore, TokenStore } from '../.
 import { getXdgPaths } from '../../src/state/paths';
 import { CliError } from '../../src/output/errors';
 import type { Credential } from '../../src/state';
-import type { AnafAuthenticator, TokenResponse } from 'anaf-ts-sdk';
+import type { AnafAuthenticator, TokenResponse } from '@florinszilagyi/anaf-ts-sdk';
 
 class FakeAuthenticator {
   authUrl = 'https://logincert.anaf.ro/oauth/authorize?fake=1';

--- a/cli/tests/services/efacturaService.test.ts
+++ b/cli/tests/services/efacturaService.test.ts
@@ -18,7 +18,7 @@ import type {
   ListMessagesResponse,
   PaginatedListMessagesResponse,
   ValidationResult,
-} from 'anaf-ts-sdk';
+} from '@florinszilagyi/anaf-ts-sdk';
 
 class FakeTokenManager {
   public refreshToken: string;

--- a/cli/tests/services/lookupService.test.ts
+++ b/cli/tests/services/lookupService.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { LookupService } from '../../src/services/lookupService';
 import { getXdgPaths } from '../../src/state/paths';
 import { CliError } from '../../src/output/errors';
-import type { AnafCompanyData, AnafCompanyResult, AnafAsyncCompanyResult } from 'anaf-ts-sdk';
+import type { AnafCompanyData, AnafCompanyResult, AnafAsyncCompanyResult } from '@florinszilagyi/anaf-ts-sdk';
 
 function freshPaths() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'anaf-cli-lookup-'));

--- a/cli/tests/services/ublService.test.ts
+++ b/cli/tests/services/ublService.test.ts
@@ -6,7 +6,7 @@ import { CompanyService, ConfigStore } from '../../src/state';
 import { getXdgPaths } from '../../src/state/paths';
 import { CliError } from '../../src/output/errors';
 import { normalizeUblBuildAction } from '../../src/actions/ublBuildAction';
-import type { AnafCompanyData } from 'anaf-ts-sdk';
+import type { AnafCompanyData } from '@florinszilagyi/anaf-ts-sdk';
 
 function freshPaths() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'anaf-cli-ubl-'));

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "Monorepo for anaf-ts-sdk (SDK) and anaf-cli (CLI)",
   "scripts": {
     "build": "pnpm -r run build",
-    "build:sdk": "pnpm --filter anaf-ts-sdk run build",
-    "build:cli": "pnpm --filter anaf-ts-sdk run build && pnpm --filter anaf-cli run build",
+    "build:sdk": "pnpm --filter @florinszilagyi/anaf-ts-sdk run build",
+    "build:cli": "pnpm --filter @florinszilagyi/anaf-ts-sdk run build && pnpm --filter @florinszilagyi/anaf-cli run build",
     "test": "pnpm -r run test",
-    "test:sdk": "pnpm --filter anaf-ts-sdk run test:unit",
-    "test:cli": "pnpm --filter anaf-cli run test",
+    "test:sdk": "pnpm --filter @florinszilagyi/anaf-ts-sdk run test:unit",
+    "test:cli": "pnpm --filter @florinszilagyi/anaf-cli run test",
     "lint": "pnpm -r run lint",
     "lint:fix": "pnpm -r run lint:fix",
-    "verify": "pnpm --filter anaf-ts-sdk run build && pnpm --filter anaf-cli run verify",
-    "dev": "pnpm --filter anaf-ts-sdk run build && pnpm --filter anaf-cli run dev"
+    "verify": "pnpm --filter @florinszilagyi/anaf-ts-sdk run build && pnpm --filter @florinszilagyi/anaf-cli run verify",
+    "dev": "pnpm --filter @florinszilagyi/anaf-ts-sdk run build && pnpm --filter @florinszilagyi/anaf-cli run dev"
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
 
   cli:
     dependencies:
-      anaf-ts-sdk:
-        specifier: workspace:*
-        version: link:../sdk
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -42,6 +39,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@florinszilagyi/anaf-ts-sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@types/jest':
         specifier: ^29.5.11
         version: 29.5.14

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "anaf-ts-sdk",
+  "name": "@florinszilagyi/anaf-ts-sdk",
   "version": "1.1.1",
   "description": "Complete TypeScript SDK for Romanian ANAF API -E-Factura, Company checks",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Renames `anaf-ts-sdk` → `@florinszilagyi/anaf-ts-sdk` and `anaf-cli` → `@florinszilagyi/anaf-cli` so both packages publish to the `florinszilagyi` npm org
- Updates all `--filter` references in root `package.json` and both CI workflow files
- Updates all `import ... from 'anaf-ts-sdk'` statements in `cli/src` and `cli/tests` to use the scoped name
- Updates the `workspace:*` devDependency reference in `cli/package.json`
- Regenerates `pnpm-lock.yaml`

## Test plan

- [ ] `pnpm install` succeeds (lock file valid)
- [ ] `pnpm run build:sdk` resolves `@florinszilagyi/anaf-ts-sdk` filter correctly
- [ ] `pnpm run build:cli` succeeds end-to-end
- [ ] `pnpm run test:cli` passes all 341 tests
- [ ] CI workflows use updated `--filter @florinszilagyi/...` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package names to use scoped namespace. The `anaf-ts-sdk` and `anaf-cli` packages are now published as `@florinszilagyi/anaf-ts-sdk` and `@florinszilagyi/anaf-cli`. Updated all related package configurations, workflows, and documentation references accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->